### PR TITLE
Refactor plugin config for lolcommits v0.10.0

### DIFF
--- a/lib/lolcommits/plugin/uploldz.rb
+++ b/lib/lolcommits/plugin/uploldz.rb
@@ -17,15 +17,6 @@ module Lolcommits
       end
 
       ##
-      # Returns the name of the plugin to identify the plugin to lolcommits.
-      #
-      # @return [String] the plugin name
-      #
-      def self.name
-        'uploldz'
-      end
-
-      ##
       # Returns position(s) of when this plugin should run during the capture
       # process. Uploading happens when a new capture is ready.
       #
@@ -33,15 +24,6 @@ module Lolcommits
       #
       def self.runner_order
         [:capture_ready]
-      end
-
-      ##
-      # Returns true if the plugin has been configured.
-      #
-      # @return [Boolean] true/false indicating if plugin is configured
-      #
-      def configured?
-        !!(!configuration['enabled'].nil? && configuration['endpoint'])
       end
 
       ##
@@ -53,7 +35,7 @@ module Lolcommits
       # configured
       #
       def valid_configuration?
-        !!(configuration['endpoint'] =~ /^http(s)?:\/\//)
+        !!(configuration[:endpoint] =~ /^http(s)?:\/\//)
       end
 
       ##
@@ -73,9 +55,9 @@ module Lolcommits
       # @return [Nil] if any error occurs
       #
       def run_capture_ready
-        debug "Posting capture to #{configuration['endpoint']}"
+        debug "Posting capture to #{configuration[:endpoint]}"
         RestClient.post(
-          configuration['endpoint'],
+          configuration[:endpoint],
           {
             file: File.new(runner.main_image),
             message: runner.message,
@@ -83,7 +65,7 @@ module Lolcommits
             author_name: runner.vcs_info.author_name,
             author_email: runner.vcs_info.author_email,
             sha: runner.sha,
-            key: configuration['optional_key']
+            key: configuration[:optional_key]
           },
           Authorization: authorization_header
         )
@@ -100,12 +82,12 @@ module Lolcommits
       # @return [Array] the option names
       #
       def plugin_options
-        %w(
-          endpoint
-          optional_key
-          optional_http_auth_username
-          optional_http_auth_password
-        )
+        [
+          :endpoint,
+          :optional_key,
+          :optional_http_auth_username,
+          :optional_http_auth_password
+        ]
       end
 
       ##
@@ -116,8 +98,8 @@ module Lolcommits
       # @return [Nil] if no username or password option set
       #
       def authorization_header
-        user     = configuration['optional_http_auth_username']
-        password = configuration['optional_http_auth_password']
+        user     = configuration[:optional_http_auth_username]
+        password = configuration[:optional_http_auth_password]
         return unless user || password
 
         'Basic ' + Base64.encode64("#{user}:#{password}").chomp

--- a/lib/lolcommits/uploldz/version.rb
+++ b/lib/lolcommits/uploldz/version.rb
@@ -1,5 +1,5 @@
 module Lolcommits
   module Uploldz
-    VERSION = "0.0.2".freeze
+    VERSION = "0.0.3".freeze
   end
 end

--- a/lolcommits-uploldz.gemspec
+++ b/lolcommits-uploldz.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rest-client"
 
-  spec.add_development_dependency "lolcommits", ">= 0.9.5"
+  spec.add_development_dependency "lolcommits", ">= 0.10.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry"

--- a/test/lolcommits/plugin/uploldz_test.rb
+++ b/test/lolcommits/plugin/uploldz_test.rb
@@ -6,14 +6,6 @@ describe Lolcommits::Plugin::Uploldz do
   include Lolcommits::TestHelpers::GitRepo
   include Lolcommits::TestHelpers::FakeIO
 
-  def plugin_name
-    "uploldz"
-  end
-
-  it "should have a name" do
-    ::Lolcommits::Plugin::Uploldz.name.must_equal plugin_name
-  end
-
   it "should run on capture ready" do
     ::Lolcommits::Plugin::Uploldz.runner_order.must_equal [:capture_ready]
   end
@@ -22,11 +14,7 @@ describe Lolcommits::Plugin::Uploldz do
     def runner
       # a simple lolcommits runner with an empty configuration Hash
       @runner ||= Lolcommits::Runner.new(
-        main_image: Tempfile.new('main_image.jpg'),
-        config: OpenStruct.new(
-          read_configuration: {},
-          loldir: File.expand_path("#{__dir__}../../../images")
-        )
+        main_image: Tempfile.new('main_image.jpg')
       )
     end
 
@@ -35,38 +23,34 @@ describe Lolcommits::Plugin::Uploldz do
     end
 
     def valid_enabled_config
-      @config ||= OpenStruct.new(
-        read_configuration: {
-          "uploldz" => {
-            "enabled" => true,
-            "endpoint" => "https://uploldz.com/uplol",
-            'optional_http_auth_username' => 'joe',
-            'optional_http_auth_password' => '1234'
-          }
-        }
-      )
+      {
+        enabled: true,
+        endpoint: "https://uploldz.com/uplol",
+        optional_http_auth_username: 'joe',
+        optional_http_auth_password: '1234'
+      }
     end
 
     describe "initalizing" do
       it "assigns runner and all plugin options" do
         plugin.runner.must_equal runner
-        plugin.options.must_equal %w(
-          enabled
-          endpoint
-          optional_key
-          optional_http_auth_username
-          optional_http_auth_password
-        )
+        plugin.options.must_equal [
+          :enabled,
+          :endpoint,
+          :optional_key,
+          :optional_http_auth_username,
+          :optional_http_auth_password
+        ]
       end
     end
 
     describe "#enabled?" do
       it "is false by default" do
-        plugin.enabled?.must_equal false
+        assert_nil plugin.enabled?
       end
 
       it "is true when configured" do
-        plugin.config = valid_enabled_config
+        plugin.configuration = valid_enabled_config
         plugin.enabled?.must_equal true
       end
     end
@@ -77,7 +61,7 @@ describe Lolcommits::Plugin::Uploldz do
 
       it "syncs lolcommits" do
         in_repo do
-          plugin.config = valid_enabled_config
+          plugin.configuration = valid_enabled_config
 
           stub_request(:post, "https://uploldz.com/uplol").to_return(status: 200)
 
@@ -99,15 +83,6 @@ describe Lolcommits::Plugin::Uploldz do
     end
 
     describe "configuration" do
-      it "returns false when not configured" do
-        plugin.configured?.must_equal false
-      end
-
-      it "returns true when configured" do
-        plugin.config = valid_enabled_config
-        plugin.configured?.must_equal true
-      end
-
       it "allows plugin options to be configured" do
         # enabled, endpoint, key, user, password
         inputs = %w(
@@ -124,24 +99,22 @@ describe Lolcommits::Plugin::Uploldz do
         end
 
         configured_plugin_options.must_equal({
-          "enabled" => true,
-          "endpoint" => "https://my-server.com/uplol",
-          "optional_key" => "key-123",
-          "optional_http_auth_username" => "joe",
-          "optional_http_auth_password" => "1337pass"
+          enabled: true,
+          endpoint: "https://my-server.com/uplol",
+          optional_key: "key-123",
+          optional_http_auth_username: "joe",
+          optional_http_auth_password: "1337pass"
         })
       end
 
       describe "#valid_configuration?" do
         it "returns false for an invalid configuration" do
-          plugin.config = OpenStruct.new(read_configuration: {
-            "lolsrv" => { "endpoint" => "gibberish" }
-          })
+          plugin.configuration = { endpoint: "gibberish" }
           plugin.valid_configuration?.must_equal false
         end
 
         it "returns true with a valid configuration" do
-          plugin.config = valid_enabled_config
+          plugin.configuration = valid_enabled_config
           plugin.valid_configuration?.must_equal true
         end
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-# necessary libs from lolcommits (allowing plugin to run)
-require 'git'
-require 'lolcommits/runner'
-require 'lolcommits/vcs_info'
-require 'lolcommits/backends/git_info'
+# lolcommits gem
+require 'lolcommits'
 
 # lolcommit test helpers
 require 'lolcommits/test_helpers/git_repo'


### PR DESCRIPTION
* require at least lolcommits >= 0.10.0
* drop`self.name` method (plugins are now identified by their gem name)
* drop calls to `configured?` (no longer available or useful)
* symbolize all plugin config keys
* bump gem version (for new plugin release)